### PR TITLE
Fix Android splash screen hang

### DIFF
--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,7 +1,7 @@
 {
   "appId": "com.nk.app",
   "appName": "nk",
-  "webDir": "www",
+  "webDir": "dist",
   "plugins": {
     "SplashScreen": {
       "launchAutoHide": false


### PR DESCRIPTION
## Summary
- update `capacitor.config.json` to use `dist` as the `webDir`

This ensures that built web assets are correctly loaded on Android so the splash screen hides properly.

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68794e75787c832cbbbafa88c2962ed2