### PR TITLE
Fix executor initialization

### DIFF
--- a/android/app/src/main/java/com/nk/app/PasskeyPlugin.java
+++ b/android/app/src/main/java/com/nk/app/PasskeyPlugin.java
@@ -23,7 +23,7 @@ import org.json.JSONObject;
 @CapacitorPlugin(name = "Passkey")
 public class PasskeyPlugin extends Plugin {
     private CredentialManager credentialManager;
-    private final Executor executor = HandlerCompat.createAsync(Looper.getMainLooper());
+    private final Executor executor = HandlerCompat.createAsync(Looper.getMainLooper())::post;
 
     @Override
     public void load() {


### PR DESCRIPTION
## Summary
- fix initialization of main thread executor in Passkey plugin

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68796bc12120832c82f92bf5c9104b31