### PR TITLE
Add native passkey test activity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,16 @@
 
         </activity>
 
+        <activity
+            android:name=".NativeTestActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/android/app/src/main/java/com/nk/app/NativeTestActivity.java
+++ b/android/app/src/main/java/com/nk/app/NativeTestActivity.java
@@ -1,0 +1,72 @@
+package com.nk.app;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.TextView;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.credentials.CreateCredentialResponse;
+import androidx.credentials.CreatePublicKeyCredentialRequest;
+import androidx.credentials.CreatePublicKeyCredentialResponse;
+import androidx.credentials.CredentialManager;
+import androidx.credentials.CredentialManagerCallback;
+import androidx.credentials.exceptions.CreateCredentialException;
+import org.json.JSONObject;
+
+public class NativeTestActivity extends AppCompatActivity {
+    private TextView output;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_native_test);
+
+        Button btn = findViewById(R.id.button_test_passkey);
+        output = findViewById(R.id.text_output);
+
+        btn.setOnClickListener(v -> testPasskey());
+    }
+
+    private void testPasskey() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            output.setText("Passkeys not supported");
+            return;
+        }
+        try {
+            JSONObject json = new JSONObject();
+            json.put("challenge", "test-challenge");
+            JSONObject rp = new JSONObject();
+            rp.put("id", "example.com");
+            rp.put("name", "Example");
+            json.put("rp", rp);
+            JSONObject user = new JSONObject();
+            user.put("id", "1");
+            user.put("name", "Test User");
+            json.put("user", user);
+
+            CreatePublicKeyCredentialRequest request =
+                    new CreatePublicKeyCredentialRequest(json.toString());
+
+            CredentialManager credentialManager = CredentialManager.create(this);
+            credentialManager.createCredentialAsync(
+                    this,
+                    request,
+                    null,
+                    this.getMainExecutor(),
+                    new CredentialManagerCallback<CreateCredentialResponse, CreateCredentialException>() {
+                        @Override
+                        public void onResult(CreateCredentialResponse result) {
+                            CreatePublicKeyCredentialResponse pk = (CreatePublicKeyCredentialResponse) result;
+                            output.setText(pk.getRegistrationResponseJson());
+                        }
+
+                        @Override
+                        public void onError(CreateCredentialException e) {
+                            output.setText("Error: " + e.getMessage());
+                        }
+                    });
+        } catch (Exception ex) {
+            output.setText("Error: " + ex.getMessage());
+        }
+    }
+}

--- a/android/app/src/main/res/layout/activity_native_test.xml
+++ b/android/app/src/main/res/layout/activity_native_test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="24dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/button_test_passkey"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Test Passkey" />
+
+    <TextView
+        android:id="@+id/text_output"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="16sp"
+        android:paddingTop="16dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add a simple Android Activity to test passkeys without Capacitor
- register the new activity in AndroidManifest with a launcher intent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a0100f260832cb08e6fd05474d827