### PR TITLE
Fix Passkey plugin loading on Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ ios/
 build/
 dist/
 www/
+.DS_Store
+android/app/src/main/assets/
 .vscode/
 .env
-.DS_Store

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation "androidx.credentials:credentials:1.5.0"
     implementation "com.google.android.gms:play-services-auth:21.3.0"
     implementation "androidx.credentials:credentials-play-services-auth:1.5.0"
+    annotationProcessor "com.getcapacitor:cap-compiler:7.4.2"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"


### PR DESCRIPTION
## Summary
- register Passkey plugin using annotation processor
- ignore Android assets directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a14654528832c886932dffba1b13e